### PR TITLE
Fix missing repository references

### DIFF
--- a/ProjectControl.CLI/ProjectControl.CLI.csproj
+++ b/ProjectControl.CLI/ProjectControl.CLI.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ProjectControl.Core\ProjectControl.Core.csproj" />
+    <ProjectReference Include="..\ProjectControl.Data\ProjectControl.Data.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/ProjectControl.Desktop/ViewModels/MainViewModel.cs
+++ b/ProjectControl.Desktop/ViewModels/MainViewModel.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using System.Windows.Threading;
 using ProjectControl.Core.Models;
 using ProjectControl.Desktop.Commands;
+using ProjectControl.Data;
 
 namespace ProjectControl.Desktop.ViewModels;
 


### PR DESCRIPTION
## Summary
- link CLI project to the Data library so EF Core types resolve
- reference `ProjectControl.Data` in `MainViewModel`

## Testing
- `dotnet build ProjectControl.CLI/ProjectControl.CLI.csproj -nologo`
- `dotnet build ProjectControl.Data/ProjectControl.Data.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_684974674b4883298059a77bee59f0a9