### PR TITLE
Fix CLI project reference to Data

### DIFF
--- a/ProjectControl.CLI/ProjectControl.CLI.csproj
+++ b/ProjectControl.CLI/ProjectControl.CLI.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ProjectControl.Core\ProjectControl.Core.csproj" />
+    <ProjectReference Include="..\ProjectControl.Data\ProjectControl.Data.csproj" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- connect ProjectControl.Data to the CLI

## Testing
- `dotnet build ProjectControl.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684976d15cb083298a1809f49b3abe29