### PR TITLE
Fix missing reference in MainViewModel

### DIFF
--- a/ProjectControl.Desktop/ViewModels/MainViewModel.cs
+++ b/ProjectControl.Desktop/ViewModels/MainViewModel.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using System.Windows.Threading;
 using ProjectControl.Core.Models;
 using ProjectControl.Desktop.Commands;
+using ProjectControl.Data;
 
 namespace ProjectControl.Desktop.ViewModels;
 


### PR DESCRIPTION
## Summary
- add missing `ProjectControl.Data` using in `MainViewModel`

## Testing
- `dotnet build ProjectControl.Desktop/ProjectControl.Desktop.csproj -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68497cb7f0608329b2e72eb6360d8fff