### PR TITLE
Fix timer display and move customer deletion to list

### DIFF
--- a/ProjectControl.Desktop/Converters/RunningTimeConverter.cs
+++ b/ProjectControl.Desktop/Converters/RunningTimeConverter.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace ProjectControl.Desktop.Converters;
+
+public class RunningTimeConverter : IMultiValueConverter
+{
+    public object? Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values.Length != 3)
+            return null;
+        if (values[0] is long total && values[2] is DateTime now)
+        {
+            long extra = 0;
+            if (values[1] is DateTime start)
+                extra = (long)(now - start).TotalSeconds;
+            var ts = TimeSpan.FromSeconds(total + extra);
+            return ts.ToString(@"hh\:mm\:ss");
+        }
+        return null;
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}

--- a/ProjectControl.Desktop/MainWindow.xaml
+++ b/ProjectControl.Desktop/MainWindow.xaml
@@ -5,6 +5,7 @@
         Title="ProjectControl" Height="350" Width="525">
     <Window.Resources>
         <conv:TimeFormatConverter x:Key="TimeFormat" />
+        <conv:RunningTimeConverter x:Key="RunningTime" />
     </Window.Resources>
     <DockPanel Margin="10">
         <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
@@ -29,7 +30,15 @@
                         <TextBlock Text="{Binding Name}" Width="120"/>
                         <TextBlock Text="{Binding Customer.Name}" Width="100" Margin="10,0,0,0"/>
                         <TextBlock Text="{Binding Status}" Width="80" Margin="10,0,0,0"/>
-                        <TextBlock Text="{Binding TotalTimeSpent, Converter={StaticResource TimeFormat}}" Margin="10,0,0,0"/>
+                        <TextBlock Margin="10,0,0,0">
+                            <TextBlock.Text>
+                                <MultiBinding Converter="{StaticResource RunningTime}">
+                                    <Binding Path="TotalTimeSpent"/>
+                                    <Binding Path="CurrentTimerStartTime"/>
+                                    <Binding Path="DataContext.Now" RelativeSource="{RelativeSource AncestorType=Window}"/>
+                                </MultiBinding>
+                            </TextBlock.Text>
+                        </TextBlock>
                     </StackPanel>
                 </DataTemplate>
             </ListBox.ItemTemplate>

--- a/ProjectControl.Desktop/ViewModels/CustomerListViewModel.cs
+++ b/ProjectControl.Desktop/ViewModels/CustomerListViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Threading.Tasks;
 using ProjectControl.Core.Models;
 using ProjectControl.Data;
@@ -6,20 +7,45 @@ using ProjectControl.Desktop.Commands;
 
 namespace ProjectControl.Desktop.ViewModels;
 
-public class CustomerListViewModel
+public class CustomerListViewModel : INotifyPropertyChanged
 {
     private readonly CustomerRepository _repo;
 
     public ObservableCollection<Customer> Customers { get; } = new();
     public DelegateCommand NewCustomerCommand { get; }
+    public DelegateCommand DeleteCustomerCommand { get; }
+
+    private Customer? _selectedCustomer;
+    public Customer? SelectedCustomer
+    {
+        get => _selectedCustomer;
+        set
+        {
+            _selectedCustomer = value;
+            DeleteCustomerCommand.RaiseCanExecuteChanged();
+            OnPropertyChanged(nameof(SelectedCustomer));
+        }
+    }
 
     public CustomerListViewModel(CustomerRepository repo)
     {
         _repo = repo;
         NewCustomerCommand = new DelegateCommand(_ => NewCustomer?.Invoke());
+        DeleteCustomerCommand = new DelegateCommand(async _ => await DeleteAsync(), _ => SelectedCustomer != null);
+    }
+
+    private async Task DeleteAsync()
+    {
+        if (SelectedCustomer == null) return;
+        await _repo.DeleteCustomerAsync(SelectedCustomer.Id);
+        await LoadCustomersAsync();
     }
 
     public event System.Action? NewCustomer;
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged(string propertyName)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
     public async Task LoadCustomersAsync()
     {

--- a/ProjectControl.Desktop/Views/CustomerEditorWindow.xaml
+++ b/ProjectControl.Desktop/Views/CustomerEditorWindow.xaml
@@ -21,7 +21,6 @@
         </StackPanel>
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
             <Button Content="Сохранить" Width="80" Margin="5" Command="{Binding SaveCommand}"/>
-            <Button Content="Удалить" Width="80" Margin="5" Command="{Binding DeleteCommand}"/>
             <Button Content="Отмена" Width="80" Margin="5" IsCancel="True"/>
         </StackPanel>
     </Grid>

--- a/ProjectControl.Desktop/Views/CustomerListWindow.xaml
+++ b/ProjectControl.Desktop/Views/CustomerListWindow.xaml
@@ -3,7 +3,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Заказчики" Height="300" Width="400">
     <DockPanel Margin="10">
-        <Button DockPanel.Dock="Bottom" Content="Новый" Width="80" Margin="0,10,0,0" Command="{Binding NewCustomerCommand}"/>
-        <ListBox ItemsSource="{Binding Customers}" DisplayMemberPath="Name"/>
+        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Удалить" Width="80" Margin="0,0,10,0" Command="{Binding DeleteCustomerCommand}"/>
+            <Button Content="Новый" Width="80" Command="{Binding NewCustomerCommand}"/>
+        </StackPanel>
+        <ListBox ItemsSource="{Binding Customers}" DisplayMemberPath="Name" SelectedItem="{Binding SelectedCustomer}"/>
     </DockPanel>
 </Window>


### PR DESCRIPTION
## Summary
- show running timer using a DispatcherTimer and multivalue converter
- move customer deletion to customer list
- remove delete button from editor

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a277acc788329971149f7a7b5e60d