### PR TITLE
Improve analytics filtering and status display

### DIFF
--- a/ProjectControl.Data/ProjectRepository.cs
+++ b/ProjectControl.Data/ProjectRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using ProjectControl.Core.Models;
@@ -18,8 +19,13 @@ public class ProjectRepository
     public async Task<List<Project>> GetProjectsAsync()
         => await _context.Projects.ToListAsync();
 
-    public async Task<List<Project>> GetProjectsWithCustomerAsync()
-        => await _context.Projects.Include(p => p.Customer).ToListAsync();
+    public async Task<List<Project>> GetProjectsWithCustomerAsync(ProjectStatus? status = null)
+    {
+        var query = _context.Projects.Include(p => p.Customer).AsQueryable();
+        if (status != null)
+            query = query.Where(p => p.Status == status);
+        return await query.ToListAsync();
+    }
 
     public async Task<Project> AddProjectAsync(Project project)
     {

--- a/ProjectControl.Desktop/ViewModels/AnalyticsViewModel.cs
+++ b/ProjectControl.Desktop/ViewModels/AnalyticsViewModel.cs
@@ -13,6 +13,7 @@ public class AnalyticsViewModel
 {
     private readonly ProjectRepository _repo;
     public ObservableCollection<Project> Projects { get; } = new();
+    public bool CompletedOnly { get; set; }
 
     public AnalyticsViewModel(ProjectRepository repo)
     {
@@ -24,7 +25,8 @@ public class AnalyticsViewModel
     public async Task LoadProjectsAsync()
     {
         Projects.Clear();
-        foreach (var p in await _repo.GetProjectsWithCustomerAsync())
+        var status = CompletedOnly ? ProjectStatus.Completed : null as ProjectStatus?;
+        foreach (var p in await _repo.GetProjectsWithCustomerAsync(status))
             Projects.Add(p);
     }
 

--- a/ProjectControl.Desktop/Views/AnalyticsWindow.xaml
+++ b/ProjectControl.Desktop/Views/AnalyticsWindow.xaml
@@ -7,6 +7,9 @@
         <conv:TimeFormatConverter x:Key="TimeFormat" />
     </Window.Resources>
     <DockPanel Margin="10">
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+            <CheckBox Content="Только завершённые" IsChecked="{Binding CompletedOnly}" Checked="OnFilterChanged" Unchecked="OnFilterChanged"/>
+        </StackPanel>
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
             <Button Content="Экспорт CSV" Width="100" Margin="0,0,10,0" Click="OnExportCsv"/>
             <TextBlock VerticalAlignment="Center"
@@ -23,6 +26,7 @@
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
+                    <GridViewColumn Header="Статус" DisplayMemberBinding="{Binding Status}" Width="100"/>
                     <GridViewColumn Header="Время" Width="80">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>

--- a/ProjectControl.Desktop/Views/AnalyticsWindow.xaml.cs
+++ b/ProjectControl.Desktop/Views/AnalyticsWindow.xaml.cs
@@ -12,6 +12,12 @@ public partial class AnalyticsWindow : Window
         DataContext = vm;
     }
 
+    private async void OnFilterChanged(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is AnalyticsViewModel vm)
+            await vm.LoadProjectsAsync();
+    }
+
     private void OnExportCsv(object sender, RoutedEventArgs e)
     {
         if (DataContext is not AnalyticsViewModel vm)


### PR DESCRIPTION
## Summary
- support status filtering when loading projects
- show status column and customer info in analytics
- add checkbox to view only completed projects and handle its events

## Testing
- `dotnet test ProjectControl.Tests/ProjectControl.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_684a341e0948832990cb6a9d2b63ba95