### PR TITLE
fix project editor customer binding

### DIFF
--- a/ProjectControl.Desktop/ViewModels/ProjectEditorViewModel.cs
+++ b/ProjectControl.Desktop/ViewModels/ProjectEditorViewModel.cs
@@ -8,7 +8,9 @@ using ProjectControl.Desktop.Commands;
 
 namespace ProjectControl.Desktop.ViewModels;
 
-public class ProjectEditorViewModel
+using System.ComponentModel;
+
+public class ProjectEditorViewModel : INotifyPropertyChanged
 {
     private readonly ProjectRepository _repo;
     private readonly CustomerRepository _customerRepo;
@@ -17,6 +19,7 @@ public class ProjectEditorViewModel
     public DelegateCommand SaveCommand { get; }
 
     public event Action? Saved;
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     public ObservableCollection<Customer> Customers { get; } = new();
     private Customer? _selectedCustomer;
@@ -28,6 +31,7 @@ public class ProjectEditorViewModel
             _selectedCustomer = value;
             if (value != null)
                 Project.CustomerId = value.Id;
+            OnPropertyChanged(nameof(SelectedCustomer));
         }
     }
 
@@ -39,6 +43,9 @@ public class ProjectEditorViewModel
         SaveCommand = new DelegateCommand(async _ => await SaveAsync());
     }
 
+    private void OnPropertyChanged(string propertyName)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
     public async Task LoadCustomersAsync()
     {
         Customers.Clear();
@@ -49,6 +56,8 @@ public class ProjectEditorViewModel
 
     private async Task SaveAsync()
     {
+        if (SelectedCustomer != null)
+            Project.CustomerId = SelectedCustomer.Id;
         if (Project.Id == 0)
             await _repo.AddProjectAsync(Project);
         else

--- a/ProjectControl.Desktop/Views/ProjectEditorWindow.xaml
+++ b/ProjectControl.Desktop/Views/ProjectEditorWindow.xaml
@@ -11,7 +11,7 @@
             <TextBlock Text="Название" />
             <TextBox Text="{Binding Project.Name, UpdateSourceTrigger=PropertyChanged}" />
             <TextBlock Text="Заказчик" Margin="0,10,0,0" />
-            <ComboBox ItemsSource="{Binding Customers}" SelectedItem="{Binding SelectedCustomer}" DisplayMemberPath="Name" />
+            <ComboBox ItemsSource="{Binding Customers}" SelectedItem="{Binding SelectedCustomer, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Name" />
             <TextBlock Text="Описание" Margin="0,10,0,0" />
             <TextBox Text="{Binding Project.Description}" AcceptsReturn="True" Height="80" />
         </StackPanel>


### PR DESCRIPTION
## Summary
- implement `INotifyPropertyChanged` in `ProjectEditorViewModel`
- update ComboBox binding to update immediately
- ensure selected customer is stored before saving

## Testing
- `dotnet test ProjectControl.Tests/ProjectControl.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684a3b19d3b48329b175c3c720876fb7