### PR TITLE
Fix CLI build and ensure Data project is referenced

### DIFF
--- a/ProjectControl.CLI/ProjectControl.CLI.csproj
+++ b/ProjectControl.CLI/ProjectControl.CLI.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ProjectControl.Core\ProjectControl.Core.csproj" />
+    <ProjectReference Include="..\ProjectControl.Data\ProjectControl.Data.csproj" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- reference `ProjectControl.Data` from the CLI so EF Core is available

## Testing
- `dotnet build ProjectControl.CLI/ProjectControl.CLI.csproj -v minimal`
- `dotnet run --project ProjectControl.CLI`
- `dotnet test ProjectControl.Tests/ProjectControl.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_684a47153bc08329a44157f76ee52089