### PR TITLE
Fix customer binding in project views

### DIFF
--- a/ProjectControl.Data/ProjectRepository.cs
+++ b/ProjectControl.Data/ProjectRepository.cs
@@ -17,11 +17,16 @@ public class ProjectRepository
     }
 
     public async Task<List<Project>> GetProjectsAsync()
-        => await _context.Projects.ToListAsync();
+        => await _context.Projects
+            .AsNoTracking()
+            .ToListAsync();
 
     public async Task<List<Project>> GetProjectsWithCustomerAsync(ProjectStatus? status = null)
     {
-        var query = _context.Projects.Include(p => p.Customer).AsQueryable();
+        var query = _context.Projects
+            .Include(p => p.Customer)
+            .AsNoTracking()
+            .AsQueryable();
         if (status != null)
             query = query.Where(p => p.Status == status);
         return await query.ToListAsync();


### PR DESCRIPTION
## Summary
- prevent EF Core change tracking from returning projects without customer info by using `AsNoTracking()`

## Testing
- `dotnet test ProjectControl.sln -c Release --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4a49b7c48329bc65dee1723f1bab