### PR TITLE
Fix customer link on project save

### DIFF
--- a/ProjectControl.Desktop/ViewModels/ProjectEditorViewModel.cs
+++ b/ProjectControl.Desktop/ViewModels/ProjectEditorViewModel.cs
@@ -57,7 +57,10 @@ public class ProjectEditorViewModel : INotifyPropertyChanged
     private async Task SaveAsync()
     {
         if (SelectedCustomer != null)
+        {
             Project.CustomerId = SelectedCustomer.Id;
+            Project.Customer = SelectedCustomer;
+        }
         if (Project.Id == 0)
             await _repo.AddProjectAsync(Project);
         else

--- a/ProjectControl.Tests/ProjectRepositoryTests.cs
+++ b/ProjectControl.Tests/ProjectRepositoryTests.cs
@@ -48,4 +48,22 @@ public class ProjectRepositoryTests
         Assert.Equal(50, updated.PaymentAmount);
         Assert.NotNull(updated.ActualCompletionDate);
     }
+
+    [Fact]
+    public async Task AddProjectWithCustomerPersistsCustomerId()
+    {
+        using var context = CreateContext();
+        var repo = new ProjectRepository(context);
+        var customer = new Customer { Name = "Cust" };
+        context.Customers.Add(customer);
+        await context.SaveChangesAsync();
+
+        var project = new Project { Name = "Test", CustomerId = customer.Id };
+        await repo.AddProjectAsync(project);
+
+        var projects = await repo.GetProjectsWithCustomerAsync();
+        Assert.Single(projects);
+        Assert.Equal(customer.Id, projects[0].CustomerId);
+        Assert.Equal("Cust", projects[0].Customer?.Name);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure selected customer object is assigned when saving a project
- test that project saved with a customer retains the link

## Testing
- `dotnet test ProjectControl.sln -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a50382d2883299e12ed7140200bcc