### PR TITLE
Add tabs for current and completed projects

### DIFF
--- a/ProjectControl.Desktop/MainWindow.xaml
+++ b/ProjectControl.Desktop/MainWindow.xaml
@@ -23,26 +23,53 @@
             <Button Content="Заказчики" Width="80" Margin="5" Click="OnCustomers"/>
             <Button Content="Аналитика" Width="80" Margin="5" Click="OnAnalytics"/>
         </StackPanel>
-        <ListBox ItemsSource="{Binding FilteredProjects}" SelectedItem="{Binding SelectedProject}">
-            <ListBox.ItemTemplate>
-                <DataTemplate>
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <TextBlock Text="{Binding Name}" Width="120"/>
-                        <TextBlock Text="{Binding Customer.Name}" Width="120" Margin="10,0,0,0"/>
-                        <TextBlock Text="{Binding Status}" Width="80" Margin="10,0,0,0"/>
-                        <TextBlock Margin="10,0,0,0">
-                            <TextBlock.Text>
-                                <MultiBinding Converter="{StaticResource RunningTime}">
-                                    <Binding Path="TotalTimeSpent"/>
-                                    <Binding Path="CurrentTimerStartTime"/>
-                                    <Binding Path="DataContext.Now" RelativeSource="{RelativeSource AncestorType=Window}"/>
-                                </MultiBinding>
-                            </TextBlock.Text>
-                        </TextBlock>
-                        <TextBlock Text="ℹ" Margin="10,0,0,0" ToolTip="{Binding Description}"/>
-                    </StackPanel>
-                </DataTemplate>
-            </ListBox.ItemTemplate>
-        </ListBox>
+        <TabControl SelectionChanged="OnTabChanged">
+            <TabItem Header="Текущие проекты">
+                <ListBox ItemsSource="{Binding FilteredProjects}" SelectedItem="{Binding SelectedProject}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <TextBlock Text="{Binding Name}" Width="120"/>
+                                <TextBlock Text="{Binding Customer.Name}" Width="120" Margin="10,0,0,0"/>
+                                <TextBlock Text="{Binding Status}" Width="80" Margin="10,0,0,0"/>
+                                <TextBlock Margin="10,0,0,0">
+                                    <TextBlock.Text>
+                                        <MultiBinding Converter="{StaticResource RunningTime}">
+                                            <Binding Path="TotalTimeSpent"/>
+                                            <Binding Path="CurrentTimerStartTime"/>
+                                            <Binding Path="DataContext.Now" RelativeSource="{RelativeSource AncestorType=Window}"/>
+                                        </MultiBinding>
+                                    </TextBlock.Text>
+                                </TextBlock>
+                                <TextBlock Text="ℹ" Margin="10,0,0,0" ToolTip="{Binding Description}"/>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </TabItem>
+            <TabItem Header="Завершенные">
+                <ListBox ItemsSource="{Binding FilteredProjects}" SelectedItem="{Binding SelectedProject}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <TextBlock Text="{Binding Name}" Width="120"/>
+                                <TextBlock Text="{Binding Customer.Name}" Width="120" Margin="10,0,0,0"/>
+                                <TextBlock Text="{Binding Status}" Width="80" Margin="10,0,0,0"/>
+                                <TextBlock Margin="10,0,0,0">
+                                    <TextBlock.Text>
+                                        <MultiBinding Converter="{StaticResource RunningTime}">
+                                            <Binding Path="TotalTimeSpent"/>
+                                            <Binding Path="CurrentTimerStartTime"/>
+                                            <Binding Path="DataContext.Now" RelativeSource="{RelativeSource AncestorType=Window}"/>
+                                        </MultiBinding>
+                                    </TextBlock.Text>
+                                </TextBlock>
+                                <TextBlock Text="ℹ" Margin="10,0,0,0" ToolTip="{Binding Description}"/>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </TabItem>
+        </TabControl>
     </DockPanel>
 </Window>

--- a/ProjectControl.Desktop/MainWindow.xaml.cs
+++ b/ProjectControl.Desktop/MainWindow.xaml.cs
@@ -85,4 +85,13 @@ public partial class MainWindow : Window
             vm.ApplyFilterSort();
         }
     }
+
+    private async void OnTabChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+    {
+        if (DataContext is MainViewModel vm && sender is System.Windows.Controls.TabControl tc)
+        {
+            vm.CompletedOnly = tc.SelectedIndex == 1;
+            await vm.LoadProjectsAsync();
+        }
+    }
 }

--- a/ProjectControl.Desktop/ViewModels/MainViewModel.cs
+++ b/ProjectControl.Desktop/ViewModels/MainViewModel.cs
@@ -45,6 +45,20 @@ public class MainViewModel : INotifyPropertyChanged
     public DelegateCommand StopCommand { get; }
     public DelegateCommand NewProjectCommand { get; }
 
+    private bool _completedOnly;
+    public bool CompletedOnly
+    {
+        get => _completedOnly;
+        set
+        {
+            if (_completedOnly != value)
+            {
+                _completedOnly = value;
+                OnPropertyChanged(nameof(CompletedOnly));
+            }
+        }
+    }
+
     private readonly DispatcherTimer _timer = new() { Interval = TimeSpan.FromSeconds(1) };
     private DateTime _now = DateTime.Now;
     public DateTime Now
@@ -78,8 +92,13 @@ public class MainViewModel : INotifyPropertyChanged
     public async Task LoadProjectsAsync()
     {
         Projects.Clear();
-        foreach (var p in await _repo.GetProjectsWithCustomerAsync())
+        var all = await _repo.GetProjectsWithCustomerAsync(CompletedOnly ? ProjectStatus.Completed : null);
+        foreach (var p in all)
+        {
+            if (!CompletedOnly && p.Status == ProjectStatus.Completed)
+                continue;
             Projects.Add(p);
+        }
         ApplyFilterSort();
     }
 


### PR DESCRIPTION
## Summary
- filter projects by completion state in `MainViewModel`
- update main window layout to use tabs
- reload projects when switching tabs

## Testing
- `dotnet build ProjectControl.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a6f79ce6883299642fea3823e80c9