### PR TITLE
Fix project tab selection

### DIFF
--- a/ProjectControl.Desktop/MainWindow.xaml.cs
+++ b/ProjectControl.Desktop/MainWindow.xaml.cs
@@ -88,10 +88,14 @@ public partial class MainWindow : Window
 
     private async void OnTabChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
     {
-        if (DataContext is MainViewModel vm && sender is System.Windows.Controls.TabControl tc)
-        {
-            vm.CompletedOnly = tc.SelectedIndex == 1;
-            await vm.LoadProjectsAsync();
-        }
+        if (DataContext is not MainViewModel vm || sender is not System.Windows.Controls.TabControl tc)
+            return;
+
+        // Ignore bubbling events from inner ListBox controls
+        if (!ReferenceEquals(e.OriginalSource, tc))
+            return;
+
+        vm.CompletedOnly = tc.SelectedIndex == 1;
+        await vm.LoadProjectsAsync();
     }
 }


### PR DESCRIPTION
## Summary
- fix `TabControl.SelectionChanged` to ignore bubbling from the inner ListBox so a project remains selected

## Testing
- `dotnet build ProjectControl.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a73ec6ccc8329ad974c0118ef720d