### PR TITLE
Fix async project loading and property notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 obj/
 **/bin/
 **/obj/
+*.db

--- a/ProjectControl.Desktop/MainWindow.xaml.cs
+++ b/ProjectControl.Desktop/MainWindow.xaml.cs
@@ -28,11 +28,11 @@ public partial class MainWindow : Window
         _ = _vm.LoadProjectsAsync();
     }
 
-    private void OnAddProject(object sender, RoutedEventArgs e)
+    private async void OnAddProject(object sender, RoutedEventArgs e)
     {
         var editorVm = new ProjectEditorViewModel(_repo, _customerRepo);
         var win = new ProjectEditorWindow(editorVm);
-        _ = editorVm.LoadCustomersAsync();
+        await editorVm.LoadCustomersAsync();
         editorVm.Saved += async () =>
         {
             await _vm.LoadProjectsAsync();

--- a/ProjectControl.Desktop/ViewModels/MainViewModel.cs
+++ b/ProjectControl.Desktop/ViewModels/MainViewModel.cs
@@ -37,6 +37,7 @@ public class MainViewModel : INotifyPropertyChanged
             PlayCommand.RaiseCanExecuteChanged();
             PauseCommand.RaiseCanExecuteChanged();
             StopCommand.RaiseCanExecuteChanged();
+            OnPropertyChanged(nameof(SelectedProject));
         }
     }
 


### PR DESCRIPTION
## Summary
- load customers before showing project editor window to avoid race and missing exceptions
- notify UI when selected project changes
- ignore database files

## Testing
- `dotnet test ProjectControl.Tests/ProjectControl.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_b_6851a13205608321bed29cf83d08949f