### PR TITLE
Enforce payment on project completion

### DIFF
--- a/ProjectControl.Data/ProjectRepository.cs
+++ b/ProjectControl.Data/ProjectRepository.cs
@@ -79,6 +79,9 @@ public class ProjectRepository
 
     public async Task CompleteProjectAsync(long projectId, PaymentStatus paymentStatus, double amount, DateTime? paymentDate, string? notes)
     {
+        if (amount <= 0)
+            throw new ArgumentException("Amount must be greater than zero", nameof(amount));
+
         await PauseTimerAsync(projectId);
         var project = await _context.Projects.FindAsync(projectId);
         if (project == null) return;

--- a/ProjectControl.Desktop/MainWindow.xaml
+++ b/ProjectControl.Desktop/MainWindow.xaml
@@ -64,6 +64,7 @@
                                         </MultiBinding>
                                     </TextBlock.Text>
                                 </TextBlock>
+                                <TextBlock Text="{Binding PaymentAmount, StringFormat={}{0:C}}" Width="80" Margin="10,0,0,0"/>
                                 <TextBlock Text="ℹ" Margin="10,0,0,0" ToolTip="{Binding Description}"/>
                             </StackPanel>
                         </DataTemplate>

--- a/ProjectControl.Desktop/MainWindow.xaml.cs
+++ b/ProjectControl.Desktop/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using ProjectControl.Data;
 using ProjectControl.Desktop.ViewModels;
@@ -24,8 +25,17 @@ public partial class MainWindow : Window
         _repo = new ProjectRepository(context);
         _customerRepo = new CustomerRepository(context);
         _vm = new MainViewModel(_repo);
+        _vm.RequestPaymentAmountAsync = ShowPaymentDialogAsync;
         DataContext = _vm;
         _ = _vm.LoadProjectsAsync();
+    }
+
+    private Task<double?> ShowPaymentDialogAsync()
+    {
+        var win = new PaymentWindow();
+        return win.ShowDialog() == true
+            ? Task.FromResult<double?>(win.Amount)
+            : Task.FromResult<double?>(null);
     }
 
     private async void OnAddProject(object sender, RoutedEventArgs e)

--- a/ProjectControl.Desktop/ViewModels/AnalyticsViewModel.cs
+++ b/ProjectControl.Desktop/ViewModels/AnalyticsViewModel.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Globalization;
 using ProjectControl.Core.Models;
 using ProjectControl.Data;
 
@@ -21,6 +22,7 @@ public class AnalyticsViewModel
     }
 
     public long TotalTimeSpent => Projects.Sum(p => p.TotalTimeSpent);
+    public double TotalPayment => Projects.Sum(p => p.PaymentAmount ?? 0);
 
     public async Task LoadProjectsAsync()
     {
@@ -33,11 +35,12 @@ public class AnalyticsViewModel
     public void ExportCsv(string filePath)
     {
         using var writer = new StreamWriter(filePath, false, Encoding.UTF8);
-        writer.WriteLine("Project,Customer,Time");
+        writer.WriteLine("Project,Customer,Time,Payment");
         foreach (var p in Projects)
         {
             string time = TimeSpan.FromSeconds(p.TotalTimeSpent).ToString(@"hh\:mm\:ss");
-            writer.WriteLine($"{Escape(p.Name)},{Escape(p.Customer?.Name ?? string.Empty)},{time}");
+            string pay = (p.PaymentAmount ?? 0).ToString(CultureInfo.InvariantCulture);
+            writer.WriteLine($"{Escape(p.Name)},{Escape(p.Customer?.Name ?? string.Empty)},{time},{pay}");
         }
     }
 

--- a/ProjectControl.Desktop/ViewModels/MainViewModel.cs
+++ b/ProjectControl.Desktop/ViewModels/MainViewModel.cs
@@ -72,6 +72,8 @@ public class MainViewModel : INotifyPropertyChanged
         }
     }
 
+    public Func<Task<double?>>? RequestPaymentAmountAsync { get; set; }
+
     public MainViewModel(ProjectRepository repo)
     {
         _repo = repo;
@@ -147,11 +149,18 @@ public class MainViewModel : INotifyPropertyChanged
         if (SelectedProject == null)
             return;
 
+        if (RequestPaymentAmountAsync == null)
+            return;
+
+        var amount = await RequestPaymentAmountAsync();
+        if (amount == null)
+            return;
+
         await _repo.CompleteProjectAsync(
             SelectedProject.Id,
-            PaymentStatus.Unpaid,
-            0,
-            null,
+            PaymentStatus.Paid,
+            amount.Value,
+            DateTime.Now,
             null);
 
         if (_activeProject?.Id == SelectedProject.Id)

--- a/ProjectControl.Desktop/Views/AnalyticsWindow.xaml
+++ b/ProjectControl.Desktop/Views/AnalyticsWindow.xaml
@@ -12,6 +12,8 @@
         </StackPanel>
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
             <Button Content="Экспорт CSV" Width="100" Margin="0,0,10,0" Click="OnExportCsv"/>
+            <TextBlock VerticalAlignment="Center" Margin="0,0,10,0"
+                       Text="{Binding TotalPayment, StringFormat={}{0:C}}" />
             <TextBlock VerticalAlignment="Center"
                        Text="{Binding TotalTimeSpent, Converter={StaticResource TimeFormat}}" />
         </StackPanel>
@@ -27,6 +29,13 @@
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
                     <GridViewColumn Header="Статус" DisplayMemberBinding="{Binding Status}" Width="100"/>
+                    <GridViewColumn Header="Оплата" Width="80">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding PaymentAmount, StringFormat={}{0:C}}"/>
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
                     <GridViewColumn Header="Время" Width="80">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>

--- a/ProjectControl.Desktop/Views/PaymentWindow.xaml
+++ b/ProjectControl.Desktop/Views/PaymentWindow.xaml
@@ -1,0 +1,19 @@
+<Window x:Class="ProjectControl.Desktop.Views.PaymentWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Оплата" Height="150" Width="250">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <StackPanel>
+            <TextBlock Text="Сумма оплаты" />
+            <TextBox x:Name="AmountBox" Margin="0,5,0,0" />
+        </StackPanel>
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="ОК" Width="80" Margin="5" IsDefault="True" Click="OnOk" />
+            <Button Content="Отмена" Width="80" Margin="5" IsCancel="True" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/ProjectControl.Desktop/Views/PaymentWindow.xaml.cs
+++ b/ProjectControl.Desktop/Views/PaymentWindow.xaml.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Windows;
+
+namespace ProjectControl.Desktop.Views;
+
+public partial class PaymentWindow : Window
+{
+    public double Amount { get; private set; }
+
+    public PaymentWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void OnOk(object sender, RoutedEventArgs e)
+    {
+        if (double.TryParse(AmountBox.Text, out var value) && value > 0)
+        {
+            Amount = value;
+            DialogResult = true;
+        }
+        else
+        {
+            MessageBox.Show("Введите положительную сумму", "Ошибка", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+    }
+}

--- a/ProjectControl.Tests/ProjectRepositoryTests.cs
+++ b/ProjectControl.Tests/ProjectRepositoryTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using ProjectControl.Core.Models;
@@ -47,6 +48,18 @@ public class ProjectRepositoryTests
         Assert.Equal(PaymentStatus.Paid, updated.PaymentStatus);
         Assert.Equal(50, updated.PaymentAmount);
         Assert.NotNull(updated.ActualCompletionDate);
+    }
+
+    [Fact]
+    public async Task CompleteProjectRequiresAmount()
+    {
+        using var context = CreateContext();
+        var repo = new ProjectRepository(context);
+        var project = new Project { Name = "Test" };
+        await repo.AddProjectAsync(project);
+
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await repo.CompleteProjectAsync(project.Id, PaymentStatus.Paid, 0, null, null));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- enforce positive amount in `CompleteProjectAsync`
- prompt for payment amount when stopping a project
- display payment on main screen and analytics
- export payment data in CSV
- add unit test for zero-amount completion

## Testing
- `dotnet test ProjectControl.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c189b88c832988564defbe1efe95