### PR TITLE
Center windows and adjust analytics filters

### DIFF
--- a/ProjectControl.Desktop/MainWindow.xaml
+++ b/ProjectControl.Desktop/MainWindow.xaml
@@ -2,7 +2,10 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:conv="clr-namespace:ProjectControl.Desktop.Converters"
-        Title="ProjectControl" Height="350" Width="525">
+        Title="ProjectControl"
+        Height="500"
+        Width="1500"
+        WindowStartupLocation="CenterScreen">
     <Window.Resources>
         <conv:TimeFormatConverter x:Key="TimeFormat" />
         <conv:RunningTimeConverter x:Key="RunningTime" />

--- a/ProjectControl.Desktop/Views/AnalyticsWindow.xaml
+++ b/ProjectControl.Desktop/Views/AnalyticsWindow.xaml
@@ -2,12 +2,15 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:conv="clr-namespace:ProjectControl.Desktop.Converters"
-        Title="Аналитика" Height="300" Width="400">
+        Title="Аналитика"
+        Height="500"
+        Width="1500"
+        WindowStartupLocation="CenterScreen">
     <Window.Resources>
         <conv:TimeFormatConverter x:Key="TimeFormat" />
     </Window.Resources>
     <DockPanel Margin="10">
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,10" VerticalAlignment="Top">
+        <StackPanel Orientation="Vertical" Margin="0,0,0,10" VerticalAlignment="Top">
             <CheckBox Content="Только завершённые" IsChecked="{Binding CompletedOnly}" Margin="0,0,10,0" Checked="OnFilterChanged" Unchecked="OnFilterChanged"/>
             <TextBlock Text="От" VerticalAlignment="Center"/>
             <DatePicker SelectedDate="{Binding FromDate}" Margin="5,0" Width="110"/>

--- a/ProjectControl.Desktop/Views/CustomerEditorWindow.xaml
+++ b/ProjectControl.Desktop/Views/CustomerEditorWindow.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="ProjectControl.Desktop.Views.CustomerEditorWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Заказчик" Height="300" Width="400">
+        Title="Заказчик" Height="300" Width="400"
+        WindowStartupLocation="CenterScreen">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>

--- a/ProjectControl.Desktop/Views/CustomerListWindow.xaml
+++ b/ProjectControl.Desktop/Views/CustomerListWindow.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="ProjectControl.Desktop.Views.CustomerListWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Заказчики" Height="300" Width="400">
+        Title="Заказчики" Height="300" Width="400"
+        WindowStartupLocation="CenterScreen">
     <DockPanel Margin="10">
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
             <Button Content="Удалить" Width="80" Margin="0,0,10,0" Command="{Binding DeleteCustomerCommand}"/>

--- a/ProjectControl.Desktop/Views/PaymentWindow.xaml
+++ b/ProjectControl.Desktop/Views/PaymentWindow.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="ProjectControl.Desktop.Views.PaymentWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Оплата" Height="150" Width="250">
+        Title="Оплата" Height="150" Width="250"
+        WindowStartupLocation="CenterScreen">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>

--- a/ProjectControl.Desktop/Views/ProjectEditorWindow.xaml
+++ b/ProjectControl.Desktop/Views/ProjectEditorWindow.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="ProjectControl.Desktop.Views.ProjectEditorWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Проект" Height="300" Width="400">
+        Title="Проект" Height="300" Width="400"
+        WindowStartupLocation="CenterScreen">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>


### PR DESCRIPTION
## Summary
- center all dialog windows on screen
- enlarge MainWindow and AnalyticsWindow to 1500x500
- stack analytics filter vertically
- update tests (no changes needed)

## Testing
- `dotnet test ProjectControl.Tests/ProjectControl.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6857c6c86140832996c730b03c51cf31