### PR TITLE
Add pastel light and dark themes

### DIFF
--- a/ProjectControl.Desktop/App.xaml
+++ b/ProjectControl.Desktop/App.xaml
@@ -3,5 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Themes/LightTheme.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/ProjectControl.Desktop/App.xaml.cs
+++ b/ProjectControl.Desktop/App.xaml.cs
@@ -4,4 +4,13 @@ namespace ProjectControl.Desktop;
 
 public partial class App : Application
 {
+    public void ApplyTheme(string theme)
+    {
+        Resources.MergedDictionaries.Clear();
+        var dict = new ResourceDictionary
+        {
+            Source = new System.Uri($"Themes/{theme}Theme.xaml", System.UriKind.Relative)
+        };
+        Resources.MergedDictionaries.Add(dict);
+    }
 }

--- a/ProjectControl.Desktop/MainWindow.xaml
+++ b/ProjectControl.Desktop/MainWindow.xaml
@@ -25,6 +25,7 @@
             <Button Content="＋" Width="50" Margin="5" Click="OnAddProject"/>
             <Button Content="Заказчики" Width="80" Margin="5" Click="OnCustomers"/>
             <Button Content="Аналитика" Width="80" Margin="5" Click="OnAnalytics"/>
+            <Button Content="Тема" Width="60" Margin="5" Click="OnToggleTheme"/>
         </StackPanel>
         <TabControl SelectionChanged="OnTabChanged">
             <TabItem Header="Текущие проекты">

--- a/ProjectControl.Desktop/MainWindow.xaml.cs
+++ b/ProjectControl.Desktop/MainWindow.xaml.cs
@@ -13,6 +13,7 @@ public partial class MainWindow : Window
     private readonly ProjectRepository _repo;
     private readonly CustomerRepository _customerRepo;
     private readonly MainViewModel _vm;
+    private bool _darkTheme;
 
     public MainWindow()
     {
@@ -77,6 +78,15 @@ public partial class MainWindow : Window
         await analyticsVm.LoadProjectsAsync();
         var win = new AnalyticsWindow(analyticsVm);
         win.ShowDialog();
+    }
+
+    private void OnToggleTheme(object sender, RoutedEventArgs e)
+    {
+        _darkTheme = !_darkTheme;
+        if (Application.Current is App app)
+        {
+            app.ApplyTheme(_darkTheme ? "Dark" : "Light");
+        }
     }
 
     private void OnFilterChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)

--- a/ProjectControl.Desktop/Themes/DarkTheme.xaml
+++ b/ProjectControl.Desktop/Themes/DarkTheme.xaml
@@ -1,0 +1,22 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Color x:Key="PrimaryBackgroundColor">#FF2E2E2E</Color>
+    <Color x:Key="PrimaryForegroundColor">#FFFFFFFF</Color>
+    <Color x:Key="AccentColor">#FF8F95B2</Color>
+
+    <SolidColorBrush x:Key="PrimaryBackground" Color="{StaticResource PrimaryBackgroundColor}"/>
+    <SolidColorBrush x:Key="PrimaryForeground" Color="{StaticResource PrimaryForegroundColor}"/>
+    <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}"/>
+
+    <Style TargetType="Window">
+        <Setter Property="Background" Value="{DynamicResource PrimaryBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryForeground}"/>
+    </Style>
+
+    <Style TargetType="Button">
+        <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="Foreground" Value="White"/>
+        <Setter Property="Margin" Value="5"/>
+        <Setter Property="Padding" Value="5,2"/>
+    </Style>
+</ResourceDictionary>

--- a/ProjectControl.Desktop/Themes/LightTheme.xaml
+++ b/ProjectControl.Desktop/Themes/LightTheme.xaml
@@ -1,0 +1,22 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Color x:Key="PrimaryBackgroundColor">#FFF7F7F7</Color>
+    <Color x:Key="PrimaryForegroundColor">#FF000000</Color>
+    <Color x:Key="AccentColor">#FFB0C4DE</Color>
+
+    <SolidColorBrush x:Key="PrimaryBackground" Color="{StaticResource PrimaryBackgroundColor}"/>
+    <SolidColorBrush x:Key="PrimaryForeground" Color="{StaticResource PrimaryForegroundColor}"/>
+    <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}"/>
+
+    <Style TargetType="Window">
+        <Setter Property="Background" Value="{DynamicResource PrimaryBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryForeground}"/>
+    </Style>
+
+    <Style TargetType="Button">
+        <Setter Property="Background" Value="{DynamicResource AccentBrush}"/>
+        <Setter Property="Foreground" Value="Black"/>
+        <Setter Property="Margin" Value="5"/>
+        <Setter Property="Padding" Value="5,2"/>
+    </Style>
+</ResourceDictionary>


### PR DESCRIPTION
## Summary
- style the app with new Light/Dark theme dictionaries
- load Light theme by default and allow runtime theme switching
- add toggle button in the main window

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet build ProjectControl.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857cbb6cdac8329b37dcffbfb4e7acd