### PR TITLE
Fix WindowChrome namespace

### DIFF
--- a/ProjectControl.Desktop/Themes/DarkTheme.xaml
+++ b/ProjectControl.Desktop/Themes/DarkTheme.xaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:shell="http://schemas.microsoft.com/winfx/2006/xaml/presentation/shell"
+                    xmlns:shell="clr-namespace:System.Windows.Shell;assembly=PresentationFramework"
                     xmlns:scm="clr-namespace:System.Windows;assembly=PresentationFramework">
     <Color x:Key="PrimaryBackgroundColor">#FF2E2E2E</Color>
     <Color x:Key="PrimaryForegroundColor">#FFFFFFFF</Color>
@@ -28,7 +28,7 @@
         </Setter>
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="Window" xmlns:shell="http://schemas.microsoft.com/winfx/2006/xaml/presentation/shell" xmlns:scm="clr-namespace:System.Windows;assembly=PresentationFramework">
+                <ControlTemplate TargetType="Window" xmlns:shell="clr-namespace:System.Windows.Shell;assembly=PresentationFramework" xmlns:scm="clr-namespace:System.Windows;assembly=PresentationFramework">
                     <Border BorderBrush="{DynamicResource AccentBrush}" BorderThickness="1">
                         <DockPanel>
                             <DockPanel x:Name="PART_TitleBar" Background="{DynamicResource WindowTitleBackground}" Height="30" DockPanel.Dock="Top" shell:WindowChrome.IsHitTestVisibleInChrome="True">

--- a/ProjectControl.Desktop/Themes/LightTheme.xaml
+++ b/ProjectControl.Desktop/Themes/LightTheme.xaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:shell="http://schemas.microsoft.com/winfx/2006/xaml/presentation/shell"
+                    xmlns:shell="clr-namespace:System.Windows.Shell;assembly=PresentationFramework"
                     xmlns:scm="clr-namespace:System.Windows;assembly=PresentationFramework">
     <Color x:Key="PrimaryBackgroundColor">#FFF7F7F7</Color>
     <Color x:Key="PrimaryForegroundColor">#FF000000</Color>
@@ -28,7 +28,7 @@
         </Setter>
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="Window" xmlns:shell="http://schemas.microsoft.com/winfx/2006/xaml/presentation/shell" xmlns:scm="clr-namespace:System.Windows;assembly=PresentationFramework">
+                <ControlTemplate TargetType="Window" xmlns:shell="clr-namespace:System.Windows.Shell;assembly=PresentationFramework" xmlns:scm="clr-namespace:System.Windows;assembly=PresentationFramework">
                     <Border BorderBrush="{DynamicResource AccentBrush}" BorderThickness="1">
                         <DockPanel>
                             <DockPanel x:Name="PART_TitleBar" Background="{DynamicResource WindowTitleBackground}" Height="30" DockPanel.Dock="Top" shell:WindowChrome.IsHitTestVisibleInChrome="True">


### PR DESCRIPTION
## Summary
- use CLR namespace for shell WindowChrome definitions

## Testing
- `dotnet test ProjectControl.sln -v minimal` *(fails: could not resolve SDK Microsoft.NET.Sdk.WindowsDesktop)*

------
https://chatgpt.com/codex/tasks/task_e_6857d042fe9083298433dd7d7d57ac75